### PR TITLE
Update board_tile.dart

### DIFF
--- a/day07_tic_tac_toe/lib/board_tile.dart
+++ b/day07_tic_tac_toe/lib/board_tile.dart
@@ -21,7 +21,7 @@ class BoardTile extends StatelessWidget {
   }
 
   Widget _widgetForTileState() {
-    Widget widget;
+    Widget widget= Image.asset(''); // initialize with a default value to avoid error
 
     switch (tileState) {
       case TileState.EMPTY:


### PR DESCRIPTION
I made this change to avoid this error:
the non-nullable local variable 'widget' must be assigned before it can be used