### PR TITLE
Convert deprecated FlatButton() to latest ElevatedButton()

### DIFF
--- a/day01_restaurant_picker/lib/main.dart
+++ b/day01_restaurant_picker/lib/main.dart
@@ -42,14 +42,14 @@ class _MyAppState extends State<MyApp> {
           Padding(
             padding: EdgeInsets.only(top: 50),
           ),
-          FlatButton(
-            onPressed: () {
-              updateIndex();
-            },
-            child: Text('Pick Restaurant'),
-            color: Colors.purple,
-            textColor: Colors.white,
-          )
+          ElevatedButton(
+            onPressed: () {},
+            child: Text('Pick Snaks'),
+            style: ButtonStyle(
+              backgroundColor: MaterialStateProperty.all<Color>(Colors.purple),
+              foregroundColor: MaterialStateProperty.all<Color>(Colors.white),
+            ),
+          ),
         ],
       ))),
     );


### PR DESCRIPTION
This commit updates all uses of FlatButton to ElevatedButton as FlatButton is deprecated in the latest version of Flutter.

This change should be transparent to users of our code.

This commit is part of an effort to update our codebase to use the latest Flutter best practices.